### PR TITLE
Add more features to huggingface reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+.DS_store

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -1,6 +1,38 @@
 {
  "cells": [
   {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:34:34.171635Z",
+     "start_time": "2024-11-27T07:34:34.161464Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ],
+   "id": "8166a1c6bb7797bb",
+   "outputs": [],
+   "execution_count": 1
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:34:34.179778Z",
+     "start_time": "2024-11-27T07:34:34.174652Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ],
+   "id": "d277e88f7ea91092",
+   "outputs": [],
+   "execution_count": 2
+  },
+  {
    "cell_type": "markdown",
    "id": "19b1960e-9e0a-401f-be15-d343902eaa21",
    "metadata": {},
@@ -23,7 +55,11 @@
    "source": [
     "from pyspark.sql import SparkSession\n",
     "\n",
-    "spark = SparkSession.builder.getOrCreate()"
+    "spark = (\n",
+    "    SparkSession.builder\n",
+    "    .config(\"spark.executor.memory\", \"20G\") \n",
+    "    .getOrCreate()\n",
+    ")"
    ],
    "outputs": [],
    "execution_count": null
@@ -33,29 +69,38 @@
    "id": "6f876028-2af5-4e63-8e9d-59afc0959267",
    "metadata": {},
    "source": [
-    "## Load a dataset as a Spark DataFrame"
+    "## Load a dataset as a Spark DataFrame\n",
+    "\n",
+    "By default the connector is using Streaming Dataset: `load_dataset(..., streaming=True)`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "id": "b8580bde-3f64-4c71-a087-8b3f71099aee",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-26T08:54:32.132099Z",
-     "start_time": "2024-11-26T08:54:28.903653Z"
+     "end_time": "2024-11-27T07:10:11.691797Z",
+     "start_time": "2024-11-27T07:09:59.993537Z"
     }
    },
-   "outputs": [],
    "source": [
     "df = spark.read.format(\"huggingface\").load(\"rotten_tomatoes\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 2
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "id": "3bbf61d1-4c2c-40e7-9790-2722637aac9d",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:10:11.707299Z",
+     "start_time": "2024-11-27T07:10:11.695157Z"
+    }
+   },
+   "source": [
+    "df.printSchema()"
+   ],
    "outputs": [
     {
      "name": "stdout",
@@ -68,130 +113,21 @@
      ]
     }
    ],
-   "source": [
-    "df.printSchema()"
-   ]
+   "execution_count": 3
   },
   {
    "cell_type": "code",
    "id": "7f7b9a2b-8733-499a-af56-3c51196d060f",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:10:52.640366Z",
+     "start_time": "2024-11-27T07:10:52.415881Z"
+    }
+   },
    "source": [
-    "# Cache the dataframe to avoid re-downloading data\n",
+    "# Cache the dataframe to avoid re-downloading data. Note this should be used for small datasets.\n",
     "df.cache()"
    ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "df121dba-2e1e-4206-b2bf-db156c298ee1",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "8530"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Trigger the cache computation\n",
-    "df.count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "8866bdfb-0782-4430-8b1e-09c65e699f41",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Row(text='the rock is destined to be the 21st century\\'s new \" conan \" and that he\\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .', label=1)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "0d9d3112-d19b-4fa8-a6fc-ba40816d1d11",
-   "metadata": {},
-   "source": [
-    "df.show(n=5)"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "225bbbef-4164-424d-a701-c6c74494ef81",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4265"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Then you can operate on this dataframe\n",
-    "df.filter(df.label == 0).count()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3932f1fd-a324-4f15-86e1-bbe1064d707a",
-   "metadata": {},
-   "source": [
-    "## Load a different split\n",
-    "You can specify the `split` data source option:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "a16e9270-eb02-4568-8739-db4dc715c274",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test_df = (\n",
-    "    spark.read.format(\"huggingface\")\n",
-    "    .option(\"split\", \"test\")\n",
-    "    .load(\"rotten_tomatoes\")\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "3aec5719-c3a1-4d18-92c8-2b0c2f4bb939",
-   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -199,26 +135,189 @@
        "DataFrame[text: string, label: bigint]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "test_df.cache()"
-   ]
+   "execution_count": 4
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "d605289d-361d-4a6c-9b70-f7ccdff3aa9d",
-   "metadata": {},
+   "id": "df121dba-2e1e-4206-b2bf-db156c298ee1",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:11:26.796618Z",
+     "start_time": "2024-11-27T07:10:59.645232Z"
+    }
+   },
+   "source": [
+    "# Trigger the cache computation\n",
+    "df.count()"
+   ],
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "                                                                                "
+      "/Users/allison.wang/.pyenv/versions/3.11.10/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown\n",
+      "  warnings.warn('resource_tracker: There appear to be %d '\n",
+      "24/11/27 15:11:14 WARN CheckAllocator: More than one DefaultAllocationManager on classpath. Choosing first found\n",
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "8530"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "cell_type": "code",
+   "id": "8866bdfb-0782-4430-8b1e-09c65e699f41",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [],
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:11:35.994254Z",
+     "start_time": "2024-11-27T07:11:35.931924Z"
+    }
+   },
+   "source": [
+    "df.head()"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Row(text='the rock is destined to be the 21st century\\'s new \" conan \" and that he\\'s going to make a splash even greater than arnold schwarzenegger , jean-claud van damme or steven segal .', label=1)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 6
+  },
+  {
+   "cell_type": "code",
+   "id": "225bbbef-4164-424d-a701-c6c74494ef81",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:11:41.923050Z",
+     "start_time": "2024-11-27T07:11:41.754692Z"
+    }
+   },
+   "source": [
+    "# Then you can operate on this dataframe\n",
+    "df.filter(df.label == 0).count()"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4265"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 7
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Load a Dataset with a configuration/subset\n",
+    "Some datasets require explicitly specifying the config name. You can pass this as a data source option."
+   ],
+   "id": "bae9bc7f48526c36"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3932f1fd-a324-4f15-86e1-bbe1064d707a",
+   "metadata": {},
+   "source": [
+    "## Load a different split\n",
+    "You can specify the `split` data source option"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "a16e9270-eb02-4568-8739-db4dc715c274",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:12:02.814196Z",
+     "start_time": "2024-11-27T07:11:54.300211Z"
+    }
+   },
+   "source": [
+    "test_df = (\n",
+    "    spark.read.format(\"huggingface\")\n",
+    "    .option(\"split\", \"test\")\n",
+    "    .load(\"rotten_tomatoes\")\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": 8
+  },
+  {
+   "cell_type": "code",
+   "id": "3aec5719-c3a1-4d18-92c8-2b0c2f4bb939",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:12:02.827481Z",
+     "start_time": "2024-11-27T07:12:02.817828Z"
+    }
+   },
+   "source": [
+    "test_df.cache()"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[text: string, label: bigint]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 9
+  },
+  {
+   "cell_type": "code",
+   "id": "d605289d-361d-4a6c-9b70-f7ccdff3aa9d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:12:16.765461Z",
+     "start_time": "2024-11-27T07:12:02.891782Z"
+    }
+   },
+   "source": [
+    "test_df.count()"
+   ],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
      ]
     },
     {
@@ -227,20 +326,25 @@
        "1066"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "test_df.count()"
-   ]
+   "execution_count": 10
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
    "id": "df1ad003-1476-4557-811b-31c3888c0030",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:12:16.905233Z",
+     "start_time": "2024-11-27T07:12:16.825661Z"
+    }
+   },
+   "source": [
+    "test_df.show(n=5)"
+   ],
    "outputs": [
     {
      "name": "stdout",
@@ -255,22 +359,181 @@
       "|the story gives a...|    1|\n",
       "|red dragon \" neve...|    1|\n",
       "+--------------------+-----+\n",
-      "only showing top 5 rows\n",
-      "\n"
+      "only showing top 5 rows\n"
      ]
     }
    ],
-   "source": [
-    "test_df.show(n=5)"
-   ]
+   "execution_count": 11
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a7f14b91-059e-4894-83d2-4ed74e0adaf9",
    "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Load a dataset with multiple shards\n",
+    "\n",
+    "This example is using the [amazon_popularity dataset](https://huggingface.co/datasets/fancyzhx/amazon_polarity) which has 4 shards (for train split)"
+   ],
+   "id": "d8481e86aeb61aaf"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:12:25.864047Z",
+     "start_time": "2024-11-27T07:12:16.919834Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "df = spark.read.format(\"huggingface\").load(\"amazon_polarity\")",
+   "id": "43759f8c136366b8",
    "outputs": [],
-   "source": []
+   "execution_count": 12
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:13:04.733705Z",
+     "start_time": "2024-11-27T07:12:50.016560Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# You can see there are 4 partitions, each correspond to one shard.\n",
+    "df.rdd.getNumPartitions()"
+   ],
+   "id": "acccc2c299be9205",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 13
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "",
+   "id": "ae7ad16dfecf0e4c"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Load a dataset without streaming\n",
+    "\n",
+    "This is equivalent to `load_dataset(..., streaming=False)`"
+   ],
+   "id": "3587271d9a4f31ac"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "df = spark.read.format(\"huggingface\").option(\"streaming\", \"false\").load(\"imdb\")",
+   "id": "5d319d7e93545788",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:15:03.325628Z",
+     "start_time": "2024-11-27T07:14:39.711977Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "df.show(n=5)",
+   "id": "bb4cdc5d8de427ea",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 13:>                                                         (0 + 1) / 1]\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+--------------------+-----+\n",
+      "|                text|label|\n",
+      "+--------------------+-----+\n",
+      "|I rented I AM CUR...|    0|\n",
+      "|\"I Am Curious: Ye...|    0|\n",
+      "|If only to avoid ...|    0|\n",
+      "|This film was pro...|    0|\n",
+      "|Oh, brother...aft...|    0|\n",
+      "+--------------------+-----+\n",
+      "only showing top 5 rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
+   "execution_count": 15
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-27T07:17:07.400787Z",
+     "start_time": "2024-11-27T07:16:43.681788Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "df.filter(df.label == 1).show(n=5)",
+   "id": "f444cb40b7ae5044",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 14:>                                                         (0 + 1) / 1]\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+--------------------+-----+\n",
+      "|                text|label|\n",
+      "+--------------------+-----+\n",
+      "|Zentropa has much...|    1|\n",
+      "|Zentropa is the m...|    1|\n",
+      "|Lars Von Trier is...|    1|\n",
+      "|*Contains spoiler...|    1|\n",
+      "|That was the firs...|    1|\n",
+      "+--------------------+-----+\n",
+      "only showing top 5 rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
+   "execution_count": 16
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "a2da54a5cefe1fa3"
   }
  ],
  "metadata": {

--- a/pyspark_huggingface/huggingface.py
+++ b/pyspark_huggingface/huggingface.py
@@ -1,4 +1,7 @@
-from pyspark.sql.datasource import DataSource, DataSourceReader
+from dataclasses import dataclass
+from typing import Sequence
+
+from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition
 from pyspark.sql.pandas.types import from_arrow_schema
 from pyspark.sql.types import StructType
 
@@ -12,10 +15,13 @@ class HuggingFaceDatasets(DataSource):
 
     Name: `huggingface`
 
+    Data Source Options:
+    - split (str): Specify which split to retrieve. Default: train
+    - config (str): Specify which subset or configuration to retrieve.
+    - streaming (bool): Specify whether to read a dataset without downloading it.
+
     Notes:
     -----
-    - The HuggingFace `datasets` library is required to use this data source. Make sure it is installed.
-    - If the schema is automatically inferred, it will use string type for all fields.
     - Currently it can only be used with public datasets. Private or gated ones are not supported.
 
     Examples
@@ -59,7 +65,8 @@ class HuggingFaceDatasets(DataSource):
     def schema(self):
         from datasets import load_dataset_builder
         dataset_name = self.options["path"]
-        ds_builder = load_dataset_builder(dataset_name)
+        config_name = self.options.get("config")
+        ds_builder = load_dataset_builder(dataset_name, config_name)
         features = ds_builder.info.features
         if features is None:
             raise Exception(
@@ -72,24 +79,44 @@ class HuggingFaceDatasets(DataSource):
         return HuggingFaceDatasetsReader(schema, self.options)
 
 
+@dataclass
+class Shard(InputPartition):
+    """ Represents a dataset shard. """
+    index: int
+
+
 class HuggingFaceDatasetsReader(DataSourceReader):
     DEFAULT_SPLIT: str = "train"
 
     def __init__(self, schema: StructType, options: dict):
+        from datasets import get_dataset_split_names, get_dataset_default_config_name
         self.schema = schema
         self.dataset_name = options["path"]
+        self.streaming = options.get("streaming", "true").lower() == "true"
+        self.config_name = options.get("config")
         # Get and validate the split name
         self.split = options.get("split", self.DEFAULT_SPLIT)
-        from datasets import get_dataset_split_names
-        valid_splits = get_dataset_split_names(self.dataset_name)
+        valid_splits = get_dataset_split_names(self.dataset_name, self.config_name)
         if self.split not in valid_splits:
             raise Exception(f"Split {self.split} is invalid. Valid options are {valid_splits}")
 
-    def read(self, partition):
+    def partitions(self) -> Sequence[InputPartition]:
+        from datasets import load_dataset
+        if not self.streaming:
+            return [Shard(index=0)]
+        else:
+            dataset = load_dataset(self.dataset_name, name=self.config_name, split=self.split, streaming=True)
+            return [Shard(index=i) for i in range(dataset.num_shards)]
+
+    def read(self, partition: Shard):
         from datasets import load_dataset
         columns = [field.name for field in self.schema.fields]
-        # TODO: add config
-        iter_dataset = load_dataset(self.dataset_name, split=self.split, streaming=True)
-        for data in iter_dataset:
-            # TODO: next spark 4.0.0 dev release will include the feature to yield as an iterator of pa.RecordBatch
-            yield tuple([data.get(column) for column in columns])
+        dataset = load_dataset(self.dataset_name, name=self.config_name, split=self.split, streaming=self.streaming)
+        if self.streaming:
+            shard = dataset.shard(num_shards=dataset.num_shards, index=partition.index)
+            for _, pa_table in shard._ex_iterable.iter_arrow():
+                yield from pa_table.select(columns).to_batches()
+        else:
+            # Get the underlying arrow table of the dataset
+            table = dataset._data
+            yield from table.select(columns).to_batches()

--- a/tests/test_huggingface.py
+++ b/tests/test_huggingface.py
@@ -1,7 +1,5 @@
 import pytest
 from pyspark.sql import SparkSession
-from pyspark_huggingface import HuggingFaceDatasets
-
 
 @pytest.fixture
 def spark():
@@ -10,6 +8,5 @@ def spark():
 
 
 def test_basic_load(spark):
-    spark.dataSource.register(HuggingFaceDatasets)
     df = spark.read.format("huggingface").load("rotten_tomatoes")
     assert df.count() == 8530  # length of the training dataset


### PR DESCRIPTION
## This PR:
- Implements the `partitions` method in DataSourceReader that uses the `num_shards` parameter from the IterableDataset to read from the a streaming dataset across multiple workers.
- Supports non-streaming mode: `load_dataset(..., streaming=False)`
- Supports dataset configuration: `load_dataset(path, name=config_name, ...)`
- Changed the return type of the data source `read` method to use an iterator of arrow batches. Note this can only be tested against the Spark master branch build (not with spark4.0.0.dev2 release).

## Example
```python
spark.read.format("huggingface")
 .option("split", "train")
 .option("config", "plain_text")
 .option("streaming", "true")
 .load("rotten_tomatoes")
```