### PR TITLE
Add HuggingFaceSink data source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ datasets = "^3.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
+pytest-dotenv = "^0.5.2"
+pytest-mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyspark_huggingface/huggingface_sink.py
+++ b/pyspark_huggingface/huggingface_sink.py
@@ -174,8 +174,7 @@ class HuggingFaceDatasetsWriter(DataSourceArrowWriter):
 
         # Get the current partition ID. Use this to generate unique filenames for each partition.
         context = TaskContext.get()
-        assert context, "No active Spark task context"
-        partition_id = context.partitionId()
+        partition_id = context.partitionId() if context else 0
 
         fs = self.get_filesystem()
         resolved_path = fs.resolve_path(self.path)

--- a/pyspark_huggingface/huggingface_sink.py
+++ b/pyspark_huggingface/huggingface_sink.py
@@ -1,6 +1,5 @@
 import ast
 import logging
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, List, Optional
 
@@ -167,7 +166,7 @@ class HuggingFaceDatasetsWriter(DataSourceArrowWriter):
 
     @property
     def prefix(self) -> str:
-        return os.path.join(self.path_in_repo, self.split)
+        return f"{self.path_in_repo}/{self.split}".strip("/")
 
     def get_delete_operations(self) -> Iterator["CommitOperationDelete"]:
         """

--- a/pyspark_huggingface/huggingface_sink.py
+++ b/pyspark_huggingface/huggingface_sink.py
@@ -143,8 +143,8 @@ class HuggingFaceDatasetsWriter(DataSourceArrowWriter):
         This is used when `overwrite=True` to clear the target directory.
         """
         from huggingface_hub import CommitOperationDelete
-        from huggingface_hub.hf_api import RepoFile
         from huggingface_hub.errors import EntryNotFoundError
+        from huggingface_hub.hf_api import RepoFile
 
         fs = self.get_filesystem()
 

--- a/pyspark_huggingface/huggingface_sink.py
+++ b/pyspark_huggingface/huggingface_sink.py
@@ -145,6 +145,17 @@ class HuggingFaceDatasetsWriter(DataSourceArrowWriter):
 
     def validate(self):
         if self.split not in ["train", "test", "validation"]:
+            """
+            TODO: Add support for custom splits.
+
+            For custom split names to be recognized, the files must have path with format:
+            `data/{split}-{iiiii}-of-{nnnnn}.parquet`
+            where `iiiii` is the part number and `nnnnn` is the total number of parts, both padded to 5 digits.
+            Example: `data/custom-00000-of-00002.parquet`
+
+            Therefore the current usage of UUID to avoid naming conflicts won't work for custom split names.
+            To fix this we can rename the files in the commit phase to satisfy the naming convention.
+            """
             raise NotImplementedError(
                 f"Only 'train', 'test', and 'validation' splits are supported. Got '{self.split}'."
             )

--- a/pyspark_huggingface/huggingface_sink.py
+++ b/pyspark_huggingface/huggingface_sink.py
@@ -277,7 +277,7 @@ class HuggingFaceDatasetsWriter(DataSourceArrowWriter):
 
         """
         Split the commit into multiple parts if necessary.
-        The HuggingFace API has a limit of 25,000 operations per commit.
+        The HuggingFace API may time out if there are too many operations in a single commit.
         """
         num_commits = math.ceil(len(operations) / self.max_operations_per_commit)
         for i in range(num_commits):

--- a/pyspark_huggingface/huggingface_sink.py
+++ b/pyspark_huggingface/huggingface_sink.py
@@ -1,0 +1,150 @@
+import ast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+from pyspark.sql.datasource import (
+    DataSource,
+    DataSourceArrowWriter,
+    WriterCommitMessage,
+)
+from pyspark.sql.types import StructType
+
+if TYPE_CHECKING:
+    from huggingface_hub import CommitOperationAdd
+    from pyarrow import RecordBatch
+
+
+class HuggingFaceSink(DataSource):
+    def __init__(self, options):
+        super().__init__(options)
+
+        if "path" not in options or not options["path"]:
+            raise Exception("You must specify a dataset name.")
+
+        kwargs = dict(self.options)
+        self.path = kwargs.pop("path")
+        self.token = kwargs.pop("token")
+        self.endpoint = kwargs.pop("endpoint", None)
+        for arg in kwargs:
+            if kwargs[arg].lower() == "true":
+                kwargs[arg] = True
+            elif kwargs[arg].lower() == "false":
+                kwargs[arg] = False
+            else:
+                try:
+                    kwargs[arg] = ast.literal_eval(kwargs[arg])
+                except ValueError:
+                    pass
+        self.kwargs = kwargs
+
+    @classmethod
+    def name(cls):
+        return "huggingfacesink"
+
+    def writer(self, schema: StructType, overwrite: bool) -> DataSourceArrowWriter:
+        return HuggingFaceDatasetsWriter(
+            path=self.path,
+            schema=schema,
+            token=self.token,
+            endpoint=self.endpoint,
+            **self.kwargs,
+        )
+
+
+@dataclass
+class HuggingFaceCommitMessage(WriterCommitMessage):
+    addition: Optional["CommitOperationAdd"]
+
+
+class HuggingFaceDatasetsWriter(DataSourceArrowWriter):
+    def __init__(
+        self,
+        path: str,
+        schema: StructType,
+        token: str,
+        endpoint: Optional[str] = None,
+        row_group_size: Optional[int] = None,
+        max_operations_per_commit=50,
+        **kwargs,
+    ):
+        self.path = path
+        self.schema = schema
+        self.token = token
+        self.endpoint = endpoint
+        self.row_group_size = row_group_size
+        self.max_operations_per_commit = max_operations_per_commit
+        self.kwargs = kwargs
+
+    def get_filesystem(self):
+        from huggingface_hub import HfFileSystem
+
+        return HfFileSystem(token=self.token, endpoint=self.endpoint)
+
+    def write(self, iterator: Iterator["RecordBatch"]) -> HuggingFaceCommitMessage:
+        import io
+
+        from huggingface_hub import CommitOperationAdd
+        from pyarrow import parquet as pq
+        from pyspark import TaskContext
+        from pyspark.sql.pandas.types import to_arrow_schema
+
+        context = TaskContext.get()
+        assert context, "No active Spark task context"
+        partition_id = context.partitionId()
+
+        schema = to_arrow_schema(self.schema)
+        parquet = io.BytesIO()
+        is_empty = True
+        with pq.ParquetWriter(parquet, schema, **self.kwargs) as writer:
+            for batch in iterator:
+                writer.write_batch(batch, row_group_size=self.row_group_size)
+                is_empty = False
+
+        if is_empty:
+            return HuggingFaceCommitMessage(addition=None)
+
+        name = f"part-{partition_id}.parquet"  # Name of the file in the repo
+        parquet.seek(0)
+        addition = CommitOperationAdd(path_in_repo=name, path_or_fileobj=parquet)
+
+        fs = self.get_filesystem()
+        resolved_path = fs.resolve_path(self.path)
+        fs._api.preupload_lfs_files(
+            repo_id=resolved_path.repo_id,
+            additions=[addition],
+            repo_type=resolved_path.repo_type,
+            revision=resolved_path.revision,
+        )
+
+        print(f"Written {name} with content")
+        return HuggingFaceCommitMessage(addition=addition)
+
+    def commit(self, messages: List[HuggingFaceCommitMessage]) -> None:  # type: ignore[override]
+        import math
+
+        fs = self.get_filesystem()
+        resolved_path = fs.resolve_path(self.path)
+        additions = [message.addition for message in messages if message.addition]
+        num_commits = math.ceil(len(additions) / self.max_operations_per_commit)
+        for i in range(num_commits):
+            begin = i * self.max_operations_per_commit
+            end = (i + 1) * self.max_operations_per_commit
+            operations = additions[begin:end]
+            commit_message = "Upload using PySpark" + (
+                f" (part {i:05d}-of-{num_commits:05d})" if num_commits > 1 else ""
+            )
+            print(operations, commit_message)
+            fs._api.create_commit(
+                repo_id=resolved_path.repo_id,
+                repo_type=resolved_path.repo_type,
+                revision=resolved_path.revision,
+                operations=operations,
+                commit_message=commit_message,
+            )
+            for addition in operations:
+                print(f"Committed {addition.path_in_repo}")
+
+    def abort(self, messages: List[HuggingFaceCommitMessage]) -> None:  # type: ignore[override]
+        additions = [message.addition for message in messages if message.addition]
+        for addition in additions:
+            print(f"Aborted {addition.path_in_repo}")

--- a/tests/test_huggingface_writer.py
+++ b/tests/test_huggingface_writer.py
@@ -1,0 +1,125 @@
+import os
+
+import pytest
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.testing import assertDataFrameEqual
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture(scope="session")
+def spark():
+    from pyspark_huggingface.huggingface_sink import HuggingFaceSink
+
+    spark = SparkSession.builder.getOrCreate()
+    spark.dataSource.register(HuggingFaceSink)
+    yield spark
+
+
+def token():
+    return os.environ["HF_TOKEN"]
+
+
+def reader(spark):
+    return spark.read.format("huggingface").option("token", token())
+
+
+def writer(df: DataFrame):
+    return df.write.format("huggingfacesink").option("token", token())
+
+
+@pytest.fixture(scope="session")
+def random_df(spark: SparkSession):
+    from pyspark.sql.functions import rand
+
+    return lambda n: spark.range(n).select((rand()).alias("value"))
+
+
+@pytest.fixture(scope="session")
+def api():
+    import huggingface_hub
+
+    return huggingface_hub.HfApi(token=token())
+
+
+@pytest.fixture(scope="session")
+def username(api):
+    return api.whoami()["name"]
+
+
+@pytest.fixture
+def repo(api, username):
+    import uuid
+
+    repo_id = f"{username}/test-{uuid.uuid4()}"
+    api.create_repo(repo_id, private=True, repo_type="dataset")
+    yield repo_id
+    api.delete_repo(repo_id, repo_type="dataset")
+
+
+def test_basic(spark, repo, random_df):
+    df = random_df(10)
+    writer(df).mode("append").save(repo)
+    actual = reader(spark).load(repo)
+    assertDataFrameEqual(df, actual)
+
+
+def test_append(spark, repo, random_df):
+    df1 = random_df(10)
+    df2 = random_df(10)
+    writer(df1).mode("append").save(repo)
+    writer(df2).mode("append").save(repo)
+    actual = reader(spark).load(repo)
+    expected = df1.union(df2)
+    assertDataFrameEqual(actual, expected)
+
+
+def test_overwrite(spark, repo, random_df):
+    df1 = random_df(10)
+    df2 = random_df(10)
+    writer(df1).mode("append").save(repo)
+    writer(df2).mode("overwrite").save(repo)
+    actual = reader(spark).load(repo)
+    assertDataFrameEqual(actual, df2)
+
+
+def test_dir(repo, random_df, api):
+    df = random_df(10)
+    writer(df).mode("append").save(repo + "/dir")
+    assert any(
+        file.path.endswith(".parquet")
+        for file in api.list_repo_tree(repo, "dir", repo_type="dataset")
+    )
+
+
+def test_revision(repo, random_df, api):
+    df = random_df(10)
+    api.create_branch(repo, branch="test", repo_type="dataset")
+    writer(df).mode("append").save(repo + "@test")
+    assert any(
+        file.path.endswith(".parquet")
+        for file in api.list_repo_tree(repo, repo_type="dataset", revision="test")
+    )
+
+
+def test_max_bytes_per_file(spark, mocker: MockerFixture):
+    from pyspark_huggingface.huggingface_sink import HuggingFaceDatasetsWriter
+
+    repo = "user/test"
+    fs = mocker.patch("huggingface_hub.HfFileSystem").return_value = mocker.MagicMock()
+    # mock fs._api.preupload_lfs_files
+    resolved_path = fs.resolve_path.return_value = mocker.MagicMock()
+    resolved_path.path_in_repo = repo
+    resolved_path.repo_id = repo
+    resolved_path.repo_type = "dataset"
+    resolved_path.revision = "main"
+
+    df = spark.range(10)
+    writer = HuggingFaceDatasetsWriter(
+        path=repo,
+        overwrite=False,
+        schema=df.schema,
+        token="token",
+        max_bytes_per_file=1,
+    )
+    writer.write(iter(df.toArrow().to_batches(max_chunksize=1)))
+    assert fs._api.preupload_lfs_files.call_count == 10

--- a/tests/test_huggingface_writer.py
+++ b/tests/test_huggingface_writer.py
@@ -6,6 +6,8 @@ from pyspark.testing import assertDataFrameEqual
 from pytest_mock import MockerFixture
 
 
+# ============== Fixtures & Helpers ==============
+
 @pytest.fixture(scope="session")
 def spark():
     from pyspark_huggingface.huggingface_sink import HuggingFaceSink
@@ -55,6 +57,8 @@ def repo(api, username):
     yield repo_id
     api.delete_repo(repo_id, repo_type="dataset")
 
+
+# ============== Tests ==============
 
 def test_basic(spark, repo, random_df):
     df = random_df(10)
@@ -106,7 +110,6 @@ def test_max_bytes_per_file(spark, mocker: MockerFixture):
 
     repo = "user/test"
     fs = mocker.patch("huggingface_hub.HfFileSystem").return_value = mocker.MagicMock()
-    # mock fs._api.preupload_lfs_files
     resolved_path = fs.resolve_path.return_value = mocker.MagicMock()
     resolved_path.path_in_repo = repo
     resolved_path.repo_id = repo

--- a/tests/test_huggingface_writer.py
+++ b/tests/test_huggingface_writer.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 import pytest
 from pyspark.sql import DataFrame, SparkSession
@@ -50,10 +51,8 @@ def username(api):
 
 @pytest.fixture
 def repo(api, username):
-    import uuid
-
     repo_id = f"{username}/test-{uuid.uuid4()}"
-    api.create_repo(repo_id, private=True, repo_type="dataset")
+    api.create_repo(repo_id, private=False, repo_type="dataset")
     yield repo_id
     api.delete_repo(repo_id, repo_type="dataset")
 
@@ -86,22 +85,26 @@ def test_overwrite(spark, repo, random_df):
     assertDataFrameEqual(actual, df2)
 
 
-def test_dir(repo, random_df, api):
-    df = random_df(10)
-    writer(df).mode("append").save(repo + "/dir")
-    assert any(
-        file.path.endswith(".parquet")
-        for file in api.list_repo_tree(repo, "dir", repo_type="dataset")
-    )
+def test_split(spark, repo, random_df):
+    df1 = random_df(10)
+    df2 = random_df(10)
+    writer(df1).mode("append").save(repo)
+    writer(df2).mode("append").options(split="test").save(repo)
+    actual1 = reader(spark).options(split="train").load(repo)
+    actual2 = reader(spark).options(split="test").load(repo)
+    assertDataFrameEqual(actual1, df1)
+    assertDataFrameEqual(actual2, df2)
 
 
 def test_revision(repo, random_df, api):
     df = random_df(10)
     api.create_branch(repo, branch="test", repo_type="dataset")
-    writer(df).mode("append").save(repo + "@test")
+    writer(df).mode("append").options(revision="test").save(repo)
     assert any(
         file.path.endswith(".parquet")
-        for file in api.list_repo_tree(repo, repo_type="dataset", revision="test")
+        for file in api.list_repo_tree(
+            repo, repo_type="dataset", revision="test", recursive=True
+        )
     )
 
 
@@ -109,20 +112,15 @@ def test_max_bytes_per_file(spark, mocker: MockerFixture):
     from pyspark_huggingface.huggingface_sink import HuggingFaceDatasetsWriter
 
     repo = "user/test"
-    fs = mocker.patch("huggingface_hub.HfFileSystem").return_value = mocker.MagicMock()
-    resolved_path = fs.resolve_path.return_value = mocker.MagicMock()
-    resolved_path.path_in_repo = repo
-    resolved_path.repo_id = repo
-    resolved_path.repo_type = "dataset"
-    resolved_path.revision = "main"
+    api = mocker.patch("huggingface_hub.HfApi").return_value = mocker.MagicMock()
 
     df = spark.range(10)
     writer = HuggingFaceDatasetsWriter(
-        path=repo,
+        repo_id=repo,
         overwrite=False,
         schema=df.schema,
         token="token",
         max_bytes_per_file=1,
     )
     writer.write(iter(df.toArrow().to_batches(max_chunksize=1)))
-    assert fs._api.preupload_lfs_files.call_count == 10
+    assert api.preupload_lfs_files.call_count == 10


### PR DESCRIPTION
Note: Description below is partially generated using AI.

This pull request introduces a new feature for writing Spark DataFrames to HuggingFace Datasets and includes associated dependencies and tests. The most important changes are the addition of the `HuggingFaceSink` data source, and new tests for the data source.

### New Feature: HuggingFaceSink Data Source

* [`pyspark_huggingface/huggingface_sink.py`](diffhunk://#diff-0a7b27c5510c008ae4bea4abeb632b2a316dc93fa14215f046b89848a5de06b1R1-R270): Added a new data source `huggingfacesink` for writing Spark DataFrames to HuggingFace Datasets. This class supports writing data in Parquet format and offers options for authentication, file size limits, etc. It also supports `overwrite` and `append` modes.
  * User must supply a HuggingFace token.
  * The writer writes Arrow batches to Parquet file using a in-memory buffer. We might want to consider writing to a temp file to reduce memory requirements.
  * Only the standard split names are supported.

#### Why is this a separate data source from HuggingFaceDatasets aka `huggingface`?

The writer has an completely different implementation from the reader:
- Writer uses the `huggingface_hub` library rather than `datasets` library to interact with HuggingFace API.
- Writer uses a different set of options.

The low cohesion between the reader and writer implementations makes it difficult to maintain them in a single class. If we want them to share the same name, we can add a wrapper class that delegates to the reader or writer based on the mode.

### Dependency Updates

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R18-R19):
  * Added `pytest-dotenv` for loading `HF_TOKEN` from `.env` file in end-to-end tests.
  * Added `pytest-mock` for mocking HuggingFace API in unit tests.

### Testing

* [`tests/test_huggingface_writer.py`](diffhunk://#diff-c973a484cc7060512a0b0d0bbfcfa95c18dde393aea52a539dd65cd345744595R1-R125): Added tests for the `HuggingFaceSink` data source.
  * End-to-end tests use real HuggingFace API.
    * `HF_TOKEN` environment variable (can be supplied in `.env`) is required to run these tests.
    * These tests create a new dataset on HuggingFace, write data to it, read it back, then delete the dataset.