### PR TITLE
Reduce requirements by deferring import until when it's actually needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-datasets = {version = "^3.2", optional = true}
-huggingface_hub = {version = "^0.27.1", optional = true}
-
-[tool.poetry.extras]
-datasets = ["datasets"]
-huggingface_hub = ["huggingface_hub"]
+datasets = "^3.2"
+huggingface_hub = "^0.27.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,12 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-datasets = "^3.2"
+datasets = {version = "^3.2", optional = true}
+huggingface_hub = {version = "^0.27.1", optional = true}
+
+[tool.poetry.extras]
+datasets = ["datasets"]
+huggingface_hub = ["huggingface_hub"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/pyspark_huggingface/huggingface.py
+++ b/pyspark_huggingface/huggingface.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional
 from pyspark.sql.datasource import DataSource
 
 if TYPE_CHECKING:
-    from pyspark.sql.datasource import DataSourceArrowWriter, DataSourceReader
+    from pyspark.sql.datasource import DataSourceWriter, DataSourceReader
     from pyspark.sql.types import StructType
 
     from pyspark_huggingface.huggingface_sink import HuggingFaceSink
@@ -54,5 +54,5 @@ class HuggingFaceDatasets(DataSource):
     def reader(self, schema: "StructType") -> "DataSourceReader":
         return self.get_source().reader(schema)
 
-    def writer(self, schema: "StructType", overwrite: bool) -> "DataSourceArrowWriter":
+    def writer(self, schema: "StructType", overwrite: bool) -> "DataSourceWriter":
         return self.get_sink().writer(schema, overwrite)

--- a/pyspark_huggingface/huggingface.py
+++ b/pyspark_huggingface/huggingface.py
@@ -5,6 +5,7 @@ from pyspark.sql.datasource import DataSource
 if TYPE_CHECKING:
     from pyspark.sql.datasource import DataSourceArrowWriter, DataSourceReader
     from pyspark.sql.types import StructType
+
     from pyspark_huggingface.huggingface_sink import HuggingFaceSink
     from pyspark_huggingface.huggingface_source import HuggingFaceSource
 

--- a/pyspark_huggingface/huggingface.py
+++ b/pyspark_huggingface/huggingface.py
@@ -1,10 +1,12 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from pyspark.sql.datasource import DataSource, DataSourceArrowWriter, DataSourceReader
-from pyspark.sql.types import StructType
+from pyspark.sql.datasource import DataSource
 
-from pyspark_huggingface.huggingface_sink import HuggingFaceSink
-from pyspark_huggingface.huggingface_source import HuggingFaceSource
+if TYPE_CHECKING:
+    from pyspark.sql.datasource import DataSourceArrowWriter, DataSourceReader
+    from pyspark.sql.types import StructType
+    from pyspark_huggingface.huggingface_sink import HuggingFaceSink
+    from pyspark_huggingface.huggingface_source import HuggingFaceSource
 
 
 class HuggingFaceDatasets(DataSource):
@@ -24,15 +26,19 @@ class HuggingFaceDatasets(DataSource):
     def __init__(self, options: dict):
         super().__init__(options)
         self.options = options
-        self.source: Optional[HuggingFaceSource] = None
-        self.sink: Optional[HuggingFaceSink] = None
+        self.source: Optional["HuggingFaceSource"] = None
+        self.sink: Optional["HuggingFaceSink"] = None
 
-    def get_source(self) -> HuggingFaceSource:
+    def get_source(self) -> "HuggingFaceSource":
+        from pyspark_huggingface.huggingface_source import HuggingFaceSource
+
         if self.source is None:
             self.source = HuggingFaceSource(self.options.copy())
         return self.source
 
-    def get_sink(self):
+    def get_sink(self) -> "HuggingFaceSink":
+        from pyspark_huggingface.huggingface_sink import HuggingFaceSink
+
         if self.sink is None:
             self.sink = HuggingFaceSink(self.options.copy())
         return self.sink
@@ -44,8 +50,8 @@ class HuggingFaceDatasets(DataSource):
     def schema(self):
         return self.get_source().schema()
 
-    def reader(self, schema: StructType) -> "DataSourceReader":
+    def reader(self, schema: "StructType") -> "DataSourceReader":
         return self.get_source().reader(schema)
 
-    def writer(self, schema: StructType, overwrite: bool) -> "DataSourceArrowWriter":
+    def writer(self, schema: "StructType", overwrite: bool) -> "DataSourceArrowWriter":
         return self.get_sink().writer(schema, overwrite)


### PR DESCRIPTION
This change allows use cases such as:
- reading a dataset on a PySpark version that doesn't have `DataSourceArrowWriter`
- writing a dataset to HuggingFace without `datasets` installed