### PR TITLE
Fix import for compatibility with older huggingface_hub

### DIFF
--- a/pyspark_huggingface/huggingface_sink.py
+++ b/pyspark_huggingface/huggingface_sink.py
@@ -160,7 +160,7 @@ class HuggingFaceDatasetsWriter(DataSourceArrowWriter):
         """
         Get all existing files of the current split.
         """
-        from huggingface_hub.errors import EntryNotFoundError
+        from huggingface_hub.utils import EntryNotFoundError
 
         try:
             objects = api.list_repo_tree(


### PR DESCRIPTION
Older versions such as 0.24 exported `EntryNotFoundError` in `huggingface_hub.utils`. https://github.com/huggingface/huggingface_hub/pull/2444 changed the definition to `huggingface_hub.errors` but the export from `huggingface_hub.utils` is kept. We update the import to make the library compatible with older versions of `huggingface_hub`.